### PR TITLE
Update to izumi 0.10.2-M8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 val V = new {
-  val distage         = "0.10.1"
+  val distage         = "0.10.2-M8"
+  val logstage        = "0.10.2-M8"
   val scalatest       = "3.1.1"
   val scalacheck      = "1.14.3"
   val http4s          = "0.21.1"
@@ -19,6 +20,7 @@ val Deps = new {
   val distageRoles   = "io.7mind.izumi" %% "distage-framework" % V.distage
   val distageDocker  = "io.7mind.izumi" %% "distage-framework-docker" % V.distage
   val distageTestkit = "io.7mind.izumi" %% "distage-testkit-scalatest" % V.distage
+  val logstageSlf4j  = "io.7mind.izumi" %% "logstage-adapter-slf4j" % V.logstage
 
   val http4sDsl    = "org.http4s" %% "http4s-dsl" % V.http4s
   val http4sServer = "org.http4s" %% "http4s-blaze-server" % V.http4s
@@ -54,6 +56,7 @@ lazy val leaderboard = project
       Deps.distageCore,
       Deps.distageRoles,
       Deps.distageConfig,
+      Deps.logstageSlf4j,
       Deps.distageDocker % Test,
       Deps.distageTestkit % Test,
       Deps.scalatest % Test,

--- a/src/main/scala/leaderboard/plugins/LeaderboardPlugin.scala
+++ b/src/main/scala/leaderboard/plugins/LeaderboardPlugin.scala
@@ -1,11 +1,11 @@
 package leaderboard.plugins
 
 import distage.StandardAxis.Repo
-import distage.{ModuleDef, TagKK}
 import distage.config.ConfigModuleDef
 import distage.plugins.PluginDef
+import distage.{ModuleDef, TagKK}
 import doobie.util.transactor.Transactor
-import izumi.distage.roles.bundled.DistageRolesModule
+import izumi.distage.roles.bundled.BundledRolesModule
 import izumi.fundamentals.platform.integration.PortCheck
 import leaderboard.LeaderboardRole
 import leaderboard.config.{PostgresCfg, PostgresPortCfg}
@@ -28,7 +28,7 @@ object LeaderboardPlugin extends PluginDef {
       make[LeaderboardRole[F]]
 
       // Bundled roles: `help` & `configwriter`
-      include(DistageRolesModule[F[Throwable, ?]](version = "1.0.0-SNAPSHOT"))
+      include(BundledRolesModule[F[Throwable, ?]](version = "1.0.0-SNAPSHOT"))
     }
 
     def api[F[+_, +_]: TagKK]: ModuleDef = new ModuleDef {


### PR DESCRIPTION
* Use `assertIO` in tests
* Explicitly add `logstage-adapter-slf4j` to redirect doobie logs to logstage (the dependency is no longer brought automatically with `distage-framework`)